### PR TITLE
Raid worker

### DIFF
--- a/Languages/English/Keyed/ToolkitRaids.xml
+++ b/Languages/English/Keyed/ToolkitRaids.xml
@@ -1,8 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <LanguageData>
     <!-- Addon Menu -->
     <ToolkitRaids.AddonMenu.Settings>Settings</ToolkitRaids.AddonMenu.Settings>
+    <ToolkitRaids.AddonMenu.ForceNoRegister>Close raid signup</ToolkitRaids.AddonMenu.ForceNoRegister>
     
     <!-- Settings -->
     <ToolkitRaids.MergeRaids.Label>Merge Twitch raids into one.</ToolkitRaids.MergeRaids.Label>

--- a/Languages/English/Keyed/ToolkitRaids.xml
+++ b/Languages/English/Keyed/ToolkitRaids.xml
@@ -4,6 +4,7 @@
     <!-- Addon Menu -->
     <ToolkitRaids.AddonMenu.Settings>Settings</ToolkitRaids.AddonMenu.Settings>
     <ToolkitRaids.AddonMenu.ForceNoRegister>Close raid signup</ToolkitRaids.AddonMenu.ForceNoRegister>
+    <ToolkitRaids.AddonMenu.ForceNewRaid>Generate new raid</ToolkitRaids.AddonMenu.ForceNewRaid>
     
     <!-- Settings -->
     <ToolkitRaids.MergeRaids.Label>Merge Twitch raids into one.</ToolkitRaids.MergeRaids.Label>

--- a/Languages/English/Keyed/ToolkitRaids.xml
+++ b/Languages/English/Keyed/ToolkitRaids.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 
 <LanguageData>
     <!-- Addon Menu -->
@@ -7,4 +7,6 @@
     <!-- Settings -->
     <ToolkitRaids.MergeRaids.Label>Merge Twitch raids into one.</ToolkitRaids.MergeRaids.Label>
     <ToolkitRaids.MergeRaids.Tooltip>When enabled, the mod will merge separate raids into one massive raid.</ToolkitRaids.MergeRaids.Tooltip>
+    <ToolkitRaids.Duration.Label>How long do viewers have, in seconds, to join the raid.</ToolkitRaids.Duration.Label>
+    <ToolkitRaids.Duration.Tooltip>The amount of time, in seconds, viewers will have to join the raid event by typing !joinraid in chat.</ToolkitRaids.Duration.Tooltip>
 </LanguageData>

--- a/ToolkitRaids/AddonMenu.cs
+++ b/ToolkitRaids/AddonMenu.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using ToolkitCore.Interfaces;
 using ToolkitCore.Windows;
-using UnityEngine;
 using Verse;
 
 namespace SirRandoo.ToolkitRaids
@@ -12,7 +11,8 @@ namespace SirRandoo.ToolkitRaids
         {
             return new List<FloatMenuOption>
             {
-                new FloatMenuOption("ToolkitRaids.AddonMenu.Settings".Translate(),
+                new FloatMenuOption(
+                    "ToolkitRaids.AddonMenu.Settings".Translate(),
                     () =>
                     {
                         var window = new Window_ModSettings(LoadedModManager.GetMod<ToolkitRaids>());
@@ -21,7 +21,8 @@ namespace SirRandoo.ToolkitRaids
                         Find.WindowStack.Add(window);
                     }
                 ),
-                new FloatMenuOption("ToolkitRaids.AddonMenu.ForceNoRegister".Translate(),
+                new FloatMenuOption(
+                    "ToolkitRaids.AddonMenu.ForceNoRegister".Translate(),
                     () =>
                     {
                         if (!UnityData.IsInMainThread)
@@ -31,9 +32,10 @@ namespace SirRandoo.ToolkitRaids
 
                         Log.Message("ToolkitRaids :: Forcibly closing registration for all pending raids...");
                         var component = Current.Game?.GetComponent<GameComponentTwitchRaid>();
-                        
+
                         component?.ForceCloseRegistry();
-                    })
+                    }
+                )
             };
         }
     }

--- a/ToolkitRaids/AddonMenu.cs
+++ b/ToolkitRaids/AddonMenu.cs
@@ -51,9 +51,9 @@ namespace SirRandoo.ToolkitRaids
                         var result = Path.GetRandomFileName()
                             .Replace(".", "")
                             .Substring(0, 8);
-                        
+
                         ToolkitRaids.RecentRaids.Enqueue(result);
-                        
+
                         Log.Message($@"ToolkitRaids :: Scheduled a new raid with leader ""{result}"".");
                     }
                 )

--- a/ToolkitRaids/AddonMenu.cs
+++ b/ToolkitRaids/AddonMenu.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using ToolkitCore.Interfaces;
 using ToolkitCore.Windows;
+using UnityEngine;
 using Verse;
 
 namespace SirRandoo.ToolkitRaids
@@ -19,7 +20,20 @@ namespace SirRandoo.ToolkitRaids
                         Find.WindowStack.TryRemove(window.GetType());
                         Find.WindowStack.Add(window);
                     }
-                )
+                ),
+                new FloatMenuOption("ToolkitRaids.AddonMenu.ForceNoRegister".Translate(),
+                    () =>
+                    {
+                        if (!UnityData.IsInMainThread)
+                        {
+                            return;
+                        }
+
+                        Log.Message("ToolkitRaids :: Forcibly closing registration for all pending raids...");
+                        var component = Current.Game?.GetComponent<GameComponentTwitchRaid>();
+                        
+                        component?.ForceCloseRegistry();
+                    })
             };
         }
     }

--- a/ToolkitRaids/AddonMenu.cs
+++ b/ToolkitRaids/AddonMenu.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using ToolkitCore.Interfaces;
 using ToolkitCore.Windows;
 using Verse;
@@ -34,6 +35,26 @@ namespace SirRandoo.ToolkitRaids
                         var component = Current.Game?.GetComponent<GameComponentTwitchRaid>();
 
                         component?.ForceCloseRegistry();
+                    }
+                ),
+                new FloatMenuOption(
+                    "ToolkitRaids.AddonMenu.ForceNewRaid".Translate(),
+                    () =>
+                    {
+                        if (!UnityData.IsInMainThread)
+                        {
+                            return;
+                        }
+
+                        Log.Message("ToolkitRaids :: Forcibly starting a new raid...");
+
+                        var result = Path.GetRandomFileName()
+                            .Replace(".", "")
+                            .Substring(0, 8);
+                        
+                        ToolkitRaids.RecentRaids.Enqueue(result);
+                        
+                        Log.Message($@"ToolkitRaids :: Scheduled a new raid with leader ""{result}"".");
                     }
                 )
             };

--- a/ToolkitRaids/CommandMethods/JoinRaidCommand.cs
+++ b/ToolkitRaids/CommandMethods/JoinRaidCommand.cs
@@ -1,4 +1,7 @@
-﻿using ToolkitCore.Models;
+﻿using ToolkitCore.Controllers;
+using ToolkitCore.Models;
+using TwitchLib.Client.Interfaces;
+using Verse;
 
 namespace SirRandoo.ToolkitRaids.CommandMethods
 {
@@ -6,6 +9,33 @@ namespace SirRandoo.ToolkitRaids.CommandMethods
     {
         public JoinRaidCommand(ToolkitChatCommand command) : base(command)
         {
+        }
+
+        public override bool CanExecute(ITwitchCommand twitchCommand)
+        {
+            if (!base.CanExecute(twitchCommand))
+            {
+                return false;
+            }
+
+            var component = Current.Game?.GetComponent<GameComponentTwitchRaid>();
+
+            return component != null && component.CanJoinRaid();
+        }
+
+        public override void Execute(ITwitchCommand twitchCommand)
+        {
+            var component = Current.Game?.GetComponent<GameComponentTwitchRaid>();
+
+            if (component == null)
+            {
+                return;
+            }
+
+            if (!component.TryJoinRaid(ViewerController.GetViewer(twitchCommand.Username)))
+            {
+                Log.Warning($@"ToolkitRaids :: Could not add ""{twitchCommand.Username}"" to any raid.");
+            }
         }
     }
 }

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -50,7 +50,7 @@ namespace SirRandoo.ToolkitRaids
 
                     if (existing == null)
                     {
-                        _raids.Add(new Raid(result));
+                        _raids.Add(new Raid(result) { Timer = Settings.Duration });
                     }
                     else
                     {
@@ -65,7 +65,7 @@ namespace SirRandoo.ToolkitRaids
                         continue;
                     }
 
-                    _raids.Add(new Raid(result));
+                    _raids.Add(new Raid(result) { Timer = Settings.Duration });
                 }
             }
 

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,8 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
-using ToolkitCore.Controllers;
 using ToolkitCore.Models;
 using UnityEngine;
 using Verse;
@@ -57,7 +56,7 @@ namespace SirRandoo.ToolkitRaids
 
                     if (existing == null)
                     {
-                        _raids.Add(new Raid(result) { Timer = Settings.Duration });
+                        _raids.Add(new Raid(result) {Timer = Settings.Duration});
                     }
                     else
                     {
@@ -72,7 +71,7 @@ namespace SirRandoo.ToolkitRaids
                         continue;
                     }
 
-                    _raids.Add(new Raid(result) { Timer = Settings.Duration });
+                    _raids.Add(new Raid(result) {Timer = Settings.Duration});
                 }
             }
 
@@ -86,7 +85,7 @@ namespace SirRandoo.ToolkitRaids
                 {
                     continue;
                 }
-                
+
                 var map = Current.Game.Maps.Where(m => m.IsPlayerHome).RandomElementWithFallback();
 
                 if (map == null)

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
@@ -9,16 +9,23 @@ using Verse;
 
 namespace SirRandoo.ToolkitRaids
 {
-    public class Raid
+    public class Raid : IExposable
     {
+        public List<string> Army = new List<string>();
+        public string Leader;
+        public float Timer;
+
         public Raid(string leader)
         {
             Leader = leader;
         }
 
-        public float Timer { get; set; }
-        public string Leader { get; }
-        public List<string> Army { get; } = new List<string>();
+        public void ExposeData()
+        {
+            Scribe_Deep.Look(ref Timer, "timer");
+            Scribe_Deep.Look(ref Leader, "leader");
+            Scribe_Collections.Look(ref Army, "army", LookMode.Value);
+        }
     }
 
     public class GameComponentTwitchRaid : GameComponent

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -86,20 +86,23 @@ namespace SirRandoo.ToolkitRaids
                 {
                     continue;
                 }
+                
+                var map = Current.Game.Maps.Where(m => m.IsPlayerHome).RandomElementWithFallback();
 
-                var parms = new IncidentParms
+                if (map == null)
                 {
-                    forced = true,
-                    generateFightersOnly = true,
-                    pawnCount = raid.Army.Count + 1,
-                    raidArrivalMode = PawnsArrivalModeDefOf.EdgeWalkIn
-                };
+                    continue;
+                }
+
+                var defaultParms = StorytellerUtility.DefaultParmsNow(IncidentCategoryDefOf.ThreatBig, map);
+                defaultParms.forced = true;
+                defaultParms.points = 36f * (raid.Army.Count + 1);
 
                 var worker = new TwitchRaidWorker {RaidData = raid, def = IncidentDefOf.RaidEnemy};
 
                 try
                 {
-                    worker.TryExecute(parms);
+                    worker.TryExecute(defaultParms);
                 }
                 catch (Exception e)
                 {

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -11,14 +11,14 @@ namespace SirRandoo.ToolkitRaids
 {
     public class Raid
     {
-        public Raid(Viewer leader)
+        public Raid(string leader)
         {
             Leader = leader;
         }
 
         public float Timer { get; set; }
-        public Viewer Leader { get; }
-        public List<Viewer> Army { get; } = new List<Viewer>();
+        public string Leader { get; }
+        public List<string> Army { get; } = new List<string>();
     }
 
     public class GameComponentTwitchRaid : GameComponent
@@ -44,37 +44,28 @@ namespace SirRandoo.ToolkitRaids
                     continue;
                 }
 
-                var viewer = !ViewerController.ViewerExists(result)
-                    ? ViewerController.CreateViewer(result)
-                    : ViewerController.GetViewer(result);
-
-                if (viewer == null)
-                {
-                    continue;
-                }
-
                 if (Settings.MergeRaids)
                 {
                     var existing = _raids.FirstOrDefault();
 
                     if (existing == null)
                     {
-                        _raids.Add(new Raid(viewer));
+                        _raids.Add(new Raid(result));
                     }
                     else
                     {
-                        existing.Army.Add(viewer);
+                        existing.Army.Add(result);
                     }
                 }
                 else
                 {
-                    if (_raids.Any(l => l.Leader.Username.Equals(viewer.Username)))
+                    if (_raids.Any(l => l.Leader.Equals(result)))
                     {
                         Log.Message("ToolkitRaids :: Received a duplicate raid.");
                         continue;
                     }
 
-                    _raids.Add(new Raid(viewer));
+                    _raids.Add(new Raid(result));
                 }
             }
 
@@ -133,7 +124,7 @@ namespace SirRandoo.ToolkitRaids
         {
             foreach (var r in _raids)
             {
-                if (r.Army.Any(s => s.Username.Equals(viewer.Username)))
+                if (r.Army.Any(s => s.Equals(viewer.Username)))
                 {
                     return false;
                 }
@@ -144,7 +135,7 @@ namespace SirRandoo.ToolkitRaids
                 return false;
             }
 
-            raid.Army.Add(viewer);
+            raid.Army.Add(viewer.Username);
             return true;
         }
 

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.CodeDom;
 using System.Collections.Generic;
 using RimWorld;
 using ToolkitCore.Models;
@@ -69,6 +70,22 @@ namespace SirRandoo.ToolkitRaids
             {
                 raid.Timer = -10f;
             }
+        }
+
+        public bool CanJoinRaid()
+        {
+            return _raids.Any(r => r.Timer > 0f);
+        }
+
+        public bool TryJoinRaid(Viewer viewer)
+        {
+            if (!_raids.TryRandomElement(out var raid))
+            {
+                return false;
+            }
+
+            raid.Army.Add(viewer);
+            return true;
         }
 
         public override void ExposeData()

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using RimWorld;
@@ -84,6 +84,14 @@ namespace SirRandoo.ToolkitRaids
 
         public bool TryJoinRaid(Viewer viewer)
         {
+            foreach (var r in _raids)
+            {
+                if (r.Army.Any(s => s.Username.Equals(viewer.Username)))
+                {
+                    return false;
+                }
+            }
+            
             if (!_raids.TryRandomElement(out var raid))
             {
                 return false;

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -95,7 +95,7 @@ namespace SirRandoo.ToolkitRaids
 
         public override void ExposeData()
         {
-            Scribe_Values.Look(ref _raids, "pendingRaids");
+            Scribe_Collections.Look(ref _raids, "pendingRaids", LookMode.Value);
         }
     }
 }

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -24,6 +24,11 @@ namespace SirRandoo.ToolkitRaids
     {
         private List<Raid> _raids = new List<Raid>();
 
+        public GameComponentTwitchRaid(Game game)
+        {
+            
+        }
+
         public override void GameComponentTick()
         {
             for (var index = _raids.Count - 1; index >= 0; index--)

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using RimWorld;
+using ToolkitCore.Models;
+using UnityEngine;
+using Verse;
+
+namespace SirRandoo.ToolkitRaids
+{
+    public class Raid
+    {
+        public Raid(Viewer leader)
+        {
+            Leader = leader;
+        }
+
+        public float Timer { get; set; }
+        public Viewer Leader { get; }
+        public List<Viewer> Army { get; } = new List<Viewer>();
+    }
+
+    public class GameComponentTwitchRaid : GameComponent
+    {
+        private List<Raid> _raids = new List<Raid>();
+
+        public override void GameComponentTick()
+        {
+            for (var index = _raids.Count - 1; index >= 0; index--)
+            {
+                var raid = _raids[index];
+
+                raid.Timer -= Time.deltaTime;
+
+                if (raid.Timer > 0f)
+                {
+                    continue;
+                }
+
+                var parms = new IncidentParms
+                {
+                    forced = true,
+                    generateFightersOnly = true,
+                    pawnCount = raid.Army.Count + 1,
+                    raidArrivalMode = PawnsArrivalModeDefOf.EdgeWalkIn
+                };
+
+                var worker = new TwitchRaidWorker {RaidData = raid, def = IncidentDefOf.RaidEnemy};
+
+                try
+                {
+                    worker.TryExecute(parms);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(
+                        $"ToolkitRaids :: Could not execute raid worker.\n{e.GetType().Name}({e.Message})\n{e.StackTrace}"
+                    );
+                }
+                finally
+                {
+                    _raids.RemoveAt(index);
+                }
+            }
+        }
+
+        public void ForceCloseRegistry()
+        {
+            foreach (var raid in _raids)
+            {
+                raid.Timer = -10f;
+            }
+        }
+
+        public override void ExposeData()
+        {
+            Scribe_Values.Look(ref _raids, "pendingRaids");
+        }
+    }
+}

--- a/ToolkitRaids/GameComponentTwitchRaid.cs
+++ b/ToolkitRaids/GameComponentTwitchRaid.cs
@@ -1,5 +1,4 @@
-using System;
-using System.CodeDom;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
@@ -28,7 +27,6 @@ namespace SirRandoo.ToolkitRaids
 
         public GameComponentTwitchRaid(Game game)
         {
-            
         }
 
         public override void GameComponentTick()
@@ -140,7 +138,7 @@ namespace SirRandoo.ToolkitRaids
                     return false;
                 }
             }
-            
+
             if (!_raids.TryRandomElement(out var raid))
             {
                 return false;

--- a/ToolkitRaids/Settings.cs
+++ b/ToolkitRaids/Settings.cs
@@ -11,10 +11,10 @@ namespace SirRandoo.ToolkitRaids
 
         public static void Draw(Rect canvas)
         {
-            var listing = new Listing_Standard{maxOneColumn = true};
+            var listing = new Listing_Standard {maxOneColumn = true};
 
             listing.Begin(canvas);
-            
+
             listing.CheckboxLabeled(
                 "ToolkitRaids.MergeRaids.Label".Translate(),
                 ref MergeRaids,
@@ -23,7 +23,7 @@ namespace SirRandoo.ToolkitRaids
 
             var (timeLabel, timeField) = ToForm(listing.GetRect(Text.LineHeight));
             var durationBuffer = Duration.ToString();
-            
+
             Widgets.Label(timeLabel, "ToolkitRaids.Duration.Label".Translate());
             Widgets.TextFieldNumeric(timeField, ref Duration, ref durationBuffer, 30, 600);
 
@@ -32,7 +32,7 @@ namespace SirRandoo.ToolkitRaids
                 Widgets.DrawHighlightIfMouseover(timeLabel);
                 TooltipHandler.TipRegion(timeLabel, "ToolkitRaids.Duration.Tooltip".Translate());
             }
-            
+
             listing.End();
         }
 

--- a/ToolkitRaids/Settings.cs
+++ b/ToolkitRaids/Settings.cs
@@ -1,18 +1,55 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using Verse;
 
 namespace SirRandoo.ToolkitRaids
 {
     public class Settings : ModSettings
     {
+        public static bool MergeRaids;
+        public static int Duration = 60;
 
         public static void Draw(Rect canvas)
         {
+            var listing = new Listing_Standard{maxOneColumn = true};
+
+            listing.Begin(canvas);
+            
+            listing.CheckboxLabeled(
+                "ToolkitRaids.MergeRaids.Label".Translate(),
+                ref MergeRaids,
+                "ToolkitRaids.MergeRaids.Tooltip".Translate()
+            );
+
+            var (timeLabel, timeField) = ToForm(listing.GetRect(Text.LineHeight));
+            var durationBuffer = Duration.ToString();
+            
+            Widgets.Label(timeLabel, "ToolkitRaids.Duration.Label".Translate());
+            Widgets.TextFieldNumeric(timeField, ref Duration, ref durationBuffer, 30, 600);
+
+            if (Mouse.IsOver(timeLabel))
+            {
+                Widgets.DrawHighlightIfMouseover(timeLabel);
+                TooltipHandler.TipRegion(timeLabel, "ToolkitRaids.Duration.Tooltip".Translate());
+            }
+            
+            listing.End();
         }
 
         public override void ExposeData()
         {
-            
+            Scribe_Values.Look(ref MergeRaids, "mergeRaids");
+            Scribe_Values.Look(ref Duration, "duration", 60);
+        }
+
+        public static Tuple<Rect, Rect> ToForm(Rect region)
+        {
+            var left = new Rect(region.x, region.y, region.width * 0.85f - 2f, region.height);
+
+            return new Tuple<Rect, Rect>(
+                left,
+                new Rect(left.x + left.width + 2f, left.y, region.width - left.width - 2f, left.height)
+            );
         }
     }
 }

--- a/ToolkitRaids/ToolkitRaids.cs
+++ b/ToolkitRaids/ToolkitRaids.cs
@@ -1,10 +1,14 @@
-﻿using UnityEngine;
+﻿using System.Collections.Concurrent;
+using TwitchLib.Client.Events;
+using UnityEngine;
 using Verse;
 
 namespace SirRandoo.ToolkitRaids
 {
     public class ToolkitRaids : Mod
     {
+        public static ConcurrentQueue<string> RecentRaids = new ConcurrentQueue<string>();
+        
         public ToolkitRaids(ModContentPack content) : base(content)
         {
             GetSettings<Settings>();
@@ -13,5 +17,18 @@ namespace SirRandoo.ToolkitRaids
         public override void DoSettingsWindowContents(Rect inRect) => Settings.Draw(inRect);
 
         public override string SettingsCategory() => nameof(ToolkitRaids);
+    }
+
+    public static class ToolkitRaidsStatic
+    {
+        static ToolkitRaidsStatic()
+        {
+            ToolkitCore.TwitchWrapper.Client.OnRaidNotification += OnRaidNotification;
+        }
+
+        private static void OnRaidNotification(object sender, OnRaidNotificationArgs args)
+        {
+            ToolkitRaids.RecentRaids.Enqueue(args.RaidNotification.Login);
+        }
     }
 }

--- a/ToolkitRaids/ToolkitRaids.cs
+++ b/ToolkitRaids/ToolkitRaids.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using ToolkitCore;
 using TwitchLib.Client.Events;
 using UnityEngine;
 using Verse;
@@ -8,22 +9,28 @@ namespace SirRandoo.ToolkitRaids
     public class ToolkitRaids : Mod
     {
         public static ConcurrentQueue<string> RecentRaids = new ConcurrentQueue<string>();
-        
+
         public ToolkitRaids(ModContentPack content) : base(content)
         {
             GetSettings<Settings>();
         }
 
-        public override void DoSettingsWindowContents(Rect inRect) => Settings.Draw(inRect);
+        public override void DoSettingsWindowContents(Rect inRect)
+        {
+            Settings.Draw(inRect);
+        }
 
-        public override string SettingsCategory() => nameof(ToolkitRaids);
+        public override string SettingsCategory()
+        {
+            return nameof(ToolkitRaids);
+        }
     }
 
     public static class ToolkitRaidsStatic
     {
         static ToolkitRaidsStatic()
         {
-            ToolkitCore.TwitchWrapper.Client.OnRaidNotification += OnRaidNotification;
+            TwitchWrapper.Client.OnRaidNotification += OnRaidNotification;
         }
 
         private static void OnRaidNotification(object sender, OnRaidNotificationArgs args)

--- a/ToolkitRaids/ToolkitRaids.csproj
+++ b/ToolkitRaids/ToolkitRaids.csproj
@@ -40,9 +40,11 @@
     <ItemGroup>
         <Compile Include="AddonMenu.cs" />
         <Compile Include="CommandMethods\JoinRaidCommand.cs" />
+        <Compile Include="GameComponentTwitchRaid.cs" />
         <Compile Include="Settings.cs" />
         <Compile Include="ToolkitRaids.cs" />
         <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="TwitchRaidWorker.cs" />
     </ItemGroup>
     <ItemGroup>
         <Content Include="..\README.md">

--- a/ToolkitRaids/TwitchRaidWorker.cs
+++ b/ToolkitRaids/TwitchRaidWorker.cs
@@ -11,7 +11,7 @@ namespace SirRandoo.ToolkitRaids
     public class TwitchRaidWorker : IncidentWorker_RaidEnemy
     {
         public Raid RaidData { get; set; }
-        
+
         protected override string GetLetterText(IncidentParms parms, List<Pawn> pawns)
         {
             var leader = pawns.FirstOrDefault(p => p.Faction.leader == p);
@@ -27,19 +27,19 @@ namespace SirRandoo.ToolkitRaids
             for (var index = 0; index < limit; index++)
             {
                 var pawn = pawns[index];
-                
+
                 if (pawn == leader)
                 {
                     continue;
                 }
-                
+
                 Viewer viewer;
 
                 try
                 {
                     viewer = RaidData.Army[index];
                 }
-                catch(IndexOutOfRangeException)
+                catch (IndexOutOfRangeException)
                 {
                     break;
                 }

--- a/ToolkitRaids/TwitchRaidWorker.cs
+++ b/ToolkitRaids/TwitchRaidWorker.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using ToolkitCore.Models;
+using UnityEngine;
+using Verse;
+
+namespace SirRandoo.ToolkitRaids
+{
+    public class TwitchRaidWorker : IncidentWorker_RaidEnemy
+    {
+        public Raid RaidData { get; set; }
+        
+        protected override string GetLetterText(IncidentParms parms, List<Pawn> pawns)
+        {
+            var leader = pawns.FirstOrDefault(p => p.Faction.leader == p);
+
+            if (leader != null)
+            {
+                var name = leader.Name as NameTriple;
+                leader.Name = new NameTriple(name?.First, RaidData.Leader.Username, name?.Last);
+            }
+
+            var limit = Mathf.Min(pawns.Count, RaidData.Army.Count);
+
+            for (var index = 0; index < limit; index++)
+            {
+                var pawn = pawns[index];
+                
+                if (pawn == leader)
+                {
+                    continue;
+                }
+                
+                Viewer viewer;
+
+                try
+                {
+                    viewer = RaidData.Army[index];
+                }
+                catch(IndexOutOfRangeException)
+                {
+                    break;
+                }
+
+                var pName = pawn.Name as NameTriple;
+                pawn.Name = new NameTriple(pName?.First, viewer.Username, pName?.Last);
+            }
+
+            return base.GetLetterText(parms, pawns);
+        }
+    }
+}

--- a/ToolkitRaids/TwitchRaidWorker.cs
+++ b/ToolkitRaids/TwitchRaidWorker.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using RimWorld;
-using ToolkitCore.Models;
 using UnityEngine;
 using Verse;
 
@@ -15,14 +14,19 @@ namespace SirRandoo.ToolkitRaids
         protected override string GetLetterText(IncidentParms parms, List<Pawn> pawns)
         {
             var leader = pawns.FirstOrDefault(p => p.Faction.leader == p);
+            var army = RaidData.Army.ToList();
 
             if (leader != null)
             {
                 var name = leader.Name as NameTriple;
                 leader.Name = new NameTriple(name?.First, RaidData.Leader, name?.Last);
             }
+            else
+            {
+                army.Add(RaidData.Leader);
+            }
 
-            var limit = Mathf.Min(pawns.Count, RaidData.Army.Count);
+            var limit = Mathf.Min(pawns.Count, army.Count);
 
             for (var index = 0; index < limit; index++)
             {
@@ -37,7 +41,7 @@ namespace SirRandoo.ToolkitRaids
 
                 try
                 {
-                    viewer = RaidData.Army[index];
+                    viewer = army[index];
                 }
                 catch (IndexOutOfRangeException)
                 {

--- a/ToolkitRaids/TwitchRaidWorker.cs
+++ b/ToolkitRaids/TwitchRaidWorker.cs
@@ -19,7 +19,7 @@ namespace SirRandoo.ToolkitRaids
             if (leader != null)
             {
                 var name = leader.Name as NameTriple;
-                leader.Name = new NameTriple(name?.First, RaidData.Leader.Username, name?.Last);
+                leader.Name = new NameTriple(name?.First, RaidData.Leader, name?.Last);
             }
 
             var limit = Mathf.Min(pawns.Count, RaidData.Army.Count);
@@ -33,7 +33,7 @@ namespace SirRandoo.ToolkitRaids
                     continue;
                 }
 
-                Viewer viewer;
+                string viewer;
 
                 try
                 {
@@ -45,7 +45,7 @@ namespace SirRandoo.ToolkitRaids
                 }
 
                 var pName = pawn.Name as NameTriple;
-                pawn.Name = new NameTriple(pName?.First, viewer.Username, pName?.Last);
+                pawn.Name = new NameTriple(pName?.First, viewer, pName?.Last);
             }
 
             return base.GetLetterText(parms, pawns);


### PR DESCRIPTION
- Ability to have raiders named after registered viewers.
- Ability to have faction leader named after the streamer that raided.
  - Currently, the streamer does *not* fallback to being named after a random pawn.
- Ability to forcibly schedule pending raids to start next tick.
- Ability to customize the duration of the sign up period.
- Ability to join via the `!joinraid` command.